### PR TITLE
Fix: Return of {Module, function} has to be nil or {:error, any()}

### DIFF
--- a/lib/cldr/plug/plug_set_locale.ex
+++ b/lib/cldr/plug/plug_set_locale.ex
@@ -339,18 +339,14 @@ defmodule Cldr.Plug.SetLocale do
     apply(module, function, [conn, options])
   end
 
-  defp return_if_valid_locale(nil) do
-    {:cont, nil}
-  end
-
-  defp return_if_valid_locale({:error, _}) do
-    {:cont, nil}
-  end
-
   defp return_if_valid_locale({:ok, locale}) do
     {:halt, locale}
   end
 
+  defp return_if_valid_locale(_) do
+    {:cont, nil}
+  end
+  
   defp put_locale({:cldr, :global}, locale, _options) do
     Cldr.put_locale(locale)
   end


### PR DESCRIPTION
>  * `{Module, function, args}` in which case the indicated function will
        be called.  If it returns `{:ok, locale}` then the locale is set to
        `locale`. `locale` must be a `t:Cldr.LanguageTag.t()`.
        Any other return is considered an error and no locale will be set.
       
Currently the return has to be either `nil` or `{:error, any()}`. This is fixed with the PR. 

https://github.com/elixir-cldr/cldr_plugs/blob/main/lib/cldr/plug/plug_set_locale.ex#L342:L352
```elixir
  defp return_if_valid_locale(nil) do
    {:cont, nil}
  end

  defp return_if_valid_locale({:error, _}) do
    {:cont, nil}
  end

  defp return_if_valid_locale({:ok, locale}) do
    {:halt, locale}
  end
```