### PR TITLE
Use `Cldr.Plug.PutLocale` in example instead of `Cldr.Plug.SetLocale`

### DIFF
--- a/lib/cldr/plug/plug_put_session.ex
+++ b/lib/cldr/plug/plug_put_session.ex
@@ -55,7 +55,7 @@ defmodule Cldr.Plug.PutSession do
         pipeline :browser do
           plug :accepts, ["html"]
           plug :fetch_session
-          plug Cldr.Plug.SetLocale,
+          plug Cldr.Plug.PutLocale,
       	    apps: [:cldr, :gettext],
       	    from: [:path, :query],
       	    gettext: MyApp.Gettext,


### PR DESCRIPTION
For consistency, use `Cldr.Plug.PutLocale` in example instead of `Cldr.Plug.SetLocale`.