### PR TITLE
Change default log level to `warning` to prevent a warning in Elixir 1.15

### DIFF
--- a/lib/cldr/plug/plug_accept_language.ex
+++ b/lib/cldr/plug/plug_accept_language.ex
@@ -13,7 +13,7 @@ defmodule Cldr.Plug.AcceptLanguage do
 
   * `:no_match_log_level` determines the logging level for
     the case when no matching locale is configured to meet the users
-    request. The default is `:warn`. If set to `nil` then no logging
+    request. The default is `:warning`. If set to `nil` then no logging
     is performed.
 
   ## Example
@@ -33,7 +33,7 @@ defmodule Cldr.Plug.AcceptLanguage do
   require Logger
 
   @language_header "accept-language"
-  @default_log_level :warn
+  @default_log_level :warning
 
   @doc false
   def init(options \\ []) do


### PR DESCRIPTION
The Logger calls have already been updated to `Logger.warning`, but this line has been missed which produces the following error now:
```
iex(2)> warning: the log level :warn is deprecated, use :warning instead
  (logger 1.15.7) lib/logger.ex:1137: Logger.elixir_level_to_erlang_level/1
  (logger 1.15.7) lib/logger.ex:862: Logger.__should_log__/2
  (ex_cldr_plugs 1.3.0) lib/cldr/plug/plug_accept_language.ex:75: Cldr.Plug.AcceptLanguage.best_match/2
  (ex_cldr_plugs 1.3.0) lib/cldr/plug/plug_accept_language.ex:49: Cldr.Plug.AcceptLanguage.call/2

request_id=F5IA_5bhKPpMPowAAAnh account_id=4000 [warning] Cldr.NoMatchingLocale: No configured locale could be matched to "de-DE,de;q=0.9"
```