### PR TITLE
fix: type spec for put_locale_from_session/2

### DIFF
--- a/lib/cldr/plug.ex
+++ b/lib/cldr/plug.ex
@@ -46,7 +46,7 @@ defmodule Cldr.Plug do
       end
 
   """
-  @spec put_locale_from_session(Cldr.LanguageTag.t(), applications) ::
+  @spec put_locale_from_session(map, applications) ::
           {:ok, Cldr.LanguageTag.t()} | {:error, {module(), String.t()}}
 
   def put_locale_from_session(locale, applications \\ [:cldr, :gettext])


### PR DESCRIPTION
I saw a confusing Dialyzer warning in my project, and I think it's caused by the type specification on `put_locale_from_session/2`.