### PR TITLE
Avoid calling put_session/3 when locale present and matching

### DIFF
--- a/lib/cldr/plug/plug_put_session.ex
+++ b/lib/cldr/plug/plug_put_session.ex
@@ -119,7 +119,11 @@ defmodule Cldr.Plug.PutSession do
             cldr_locale
           end
 
-        put_session(conn, PutLocale.session_key(), locale)
+        if get_session(conn, PutLocale.session_key()) != locale do
+          put_session(conn, PutLocale.session_key(), locale)
+        else
+          conn
+        end
 
       _other ->
         conn

--- a/test/plug/plug_put_session_test.exs
+++ b/test/plug/plug_put_session_test.exs
@@ -11,6 +11,18 @@ defmodule Cldr.Plug.SetSession.Test do
     assert get_session(conn, Cldr.Plug.SetLocale.session_key()) |> to_string() == "es-ES"
   end
 
+  test "that the session is not written to needlessly" do
+    conn = conn(:get, "/hello/es", %{this: "thing"})
+    conn = MyRouter.call(conn, MyRouter.init([]))
+
+    conn = recycle_cookies(conn(:get, "/hello/es", %{this: "thing"}), conn)
+    conn = MyRouter.call(conn, MyRouter.init([]))
+
+    assert conn.resp_cookies == %{}
+
+    assert get_session(conn, Cldr.Plug.SetLocale.session_key()) |> to_string() == "es-ES"
+  end
+
   test "that the session is set for complex locale (not a cldr locale name)" do
     locale = "es-u-ca-coptic"
 


### PR DESCRIPTION
Hey @kipcole9 

This patch adds a check before the call to `put_session/3` in the `Cldr.Plug.PutSession` plug to avoid needlessly rewriting the session cookie. As this plug is usually run on every request, the added bandwidth for the `Set-Cookie` header becomes significant at scale, also the presence of this header may cause caching infrastructure to treat responses as private.

Hope this is in your interest.

Best wishes and thanks for all the hard work for the community!
malte